### PR TITLE
Feat/category filters 1

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -37,6 +37,14 @@ module.exports = [
       name: `publications`,
     },
   },
+  "gatsby-transformer-json",
+  {
+    resolve: `gatsby-source-filesystem`,
+    options: {
+      path: `${dir}/content/tags`,
+      name: `tags`,
+    },
+  },
   {
     resolve: "gatsby-plugin-feed",
     options: {

--- a/config/site.js
+++ b/config/site.js
@@ -3,6 +3,7 @@ module.exports = {
   description: "A student-run publication from Hunter College covering computer science topics",
   siteUrl: "http://www.huntercs.org/",
   navbar: {
-    links: ["Daedalus", "Hunter", "Silicon Valley", "Tech At Large"],
+  	tags: ["Daedalus", "Hunter", "Silicon Alley"],
+    links: ["About", "Tags"],
   },
 };

--- a/content/publications/sample1.md
+++ b/content/publications/sample1.md
@@ -1,6 +1,7 @@
 ---
 title: Sample title 1
 date: 2020-08-01
+tags: ["Daedalus"]
 ---
 
 # h1 Heading

--- a/content/publications/sample2.mdx
+++ b/content/publications/sample2.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sample title 2
 date: 2020-08-02
+tags: ["Daedalus", "Hunter", "How-To"]
 ---
 
 export const Evenoddp = ({num}) => (<>{(num % 2 === 0).toString()}</>)

--- a/content/publications/sample3/index.md
+++ b/content/publications/sample3/index.md
@@ -1,7 +1,7 @@
 ---
 title: Sample title 3
 date: 2020-08-03
-tags: ["Daedalus", "NYC"]
+tags: ["Daedalus", "Silicon Alley", "NYC", "Python"]
 ---
 
 Yay

--- a/content/publications/sample3/index.md
+++ b/content/publications/sample3/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sample title 3
 date: 2020-08-03
+tags: ["Daedalus", "NYC"]
 ---
 
 Yay

--- a/content/tags/tags.json
+++ b/content/tags/tags.json
@@ -1,0 +1,12 @@
+[
+	{
+		"tag": "Silicon Alley",
+		"description": "The NYC tech scene",
+		"related": ["Hunter"]
+	},
+	{
+		"tag": "Daedalus",
+		"description": "Hunter's computer science honors cohort",
+		"related": ["Hunter"]
+	}
+]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gatsby-plugin-prefetch-google-fonts": "^1.4.3",
     "gatsby-plugin-root-import": "^2.0.5",
     "gatsby-source-filesystem": "^2.3.23",
+    "gatsby-transformer-json": "^2.4.11",
     "moment": "^2.27.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -93,10 +93,22 @@ const Header = ({ title, toggleTheme }) => {
         className={classes.toolbarSecondary}
       >
         {tags.map((link) => (
-          <NavLink className={classes.toolbarLink} to={`/tag/${normalizeURL(link)}`}>{link}</NavLink>
+          <NavLink 
+            className={classes.toolbarLink} 
+            to={`/tag/${normalizeURL(link)}`}
+            key={link}
+          >
+            {link}
+          </NavLink>
         ))}
         {links.map((link) => (
-          <NavLink className={classes.toolbarLink} to={`/${normalizeURL(link)}`}>{link}</NavLink>
+          <NavLink 
+            className={classes.toolbarLink} 
+            to={`/${normalizeURL(link)}`}
+            key={link}
+          >
+            {link}
+          </NavLink>
         ))}
 
         <IconButton onClick={toggleTheme}>

--- a/src/layout/Header.jsx
+++ b/src/layout/Header.jsx
@@ -26,7 +26,28 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const normalizeUrl = (url) => url.replace(/ /g, "-").toLowerCase();
+//see gatsby-node.js
+const normalizeURL = (url) => encodeURIComponent(url.replace(/ /g, "-").toLowerCase());
+
+/**
+ * Renders a nav link (Gatsby Link)
+ * Props:
+ * @children   rendered as visible text
+ * @className  passed as the underlying Link's className
+ * @to         the local url to go to
+ */
+const NavLink = (props) => (
+  <Link
+    to={props.to}
+    component={GatsbyLink}
+    color="textSecondary"
+    noWrap
+    variant="h5"
+    className={props.className}
+  >
+    {props.children}
+  </Link>
+);
 
 const Header = ({ title, toggleTheme }) => {
   const { site } = useStaticQuery(graphql`
@@ -35,6 +56,7 @@ const Header = ({ title, toggleTheme }) => {
         siteMetadata {
           navbar {
             links
+            tags
           }
         }
       }
@@ -42,6 +64,7 @@ const Header = ({ title, toggleTheme }) => {
   `);
 
   const links = site.siteMetadata.navbar.links;
+  const tags = site.siteMetadata.navbar.tags;
   const classes = useStyles();
   return (
     <>
@@ -69,18 +92,11 @@ const Header = ({ title, toggleTheme }) => {
         variant="dense"
         className={classes.toolbarSecondary}
       >
+        {tags.map((link) => (
+          <NavLink className={classes.toolbarLink} to={`/tag/${normalizeURL(link)}`}>{link}</NavLink>
+        ))}
         {links.map((link) => (
-          <Link
-            to={`/${normalizeUrl(link)}`}
-            component={GatsbyLink}
-            color="textSecondary"
-            noWrap
-            key={link}
-            variant="h5"
-            className={classes.toolbarLink}
-          >
-            {link}
-          </Link>
+          <NavLink className={classes.toolbarLink} to={`/${normalizeURL(link)}`}>{link}</NavLink>
         ))}
 
         <IconButton onClick={toggleTheme}>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -25,7 +25,10 @@ const Index = () => {
 
   const recent = useStaticQuery(graphql`
     {
-      allMdx(sort: { fields: frontmatter___date, order: DESC }) {
+      allMdx(
+        sort: { fields: frontmatter___date, order: DESC }
+        filter: { fields: { collection: { eq: "publications" } } }
+      ) {
         edges {
           node {
             frontmatter {

--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     listStyle: "none",
     padding: theme.spacing(1),
+    textAlign: "center",
   },
   chip: {
     margin: theme.spacing(2),

--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -1,0 +1,68 @@
+import React from "react";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import Chip from '@material-ui/core/Chip';
+import Paper from '@material-ui/core/Paper';
+import Link from "@material-ui/core/Link";
+import { makeStyles } from "@material-ui/core/styles";
+import { Link as GatsbyLink, graphql } from "gatsby";
+
+import Layout from "src/layout";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    listStyle: "none",
+    padding: theme.spacing(1),
+  },
+  chip: {
+    margin: theme.spacing(2),
+  },
+  chipContainer: {
+    display: "inline"
+  },
+}));
+
+//see gatsby-node.js
+const normalizeURL = (url) => encodeURIComponent(url.replace(/ /g, "-").toLowerCase());
+
+const TagsPage = (props) => {
+  //a list of all tags ever used in any article
+  const tags = props.data.allMdx.group;
+  //css styles
+  const classes = useStyles();
+  return (
+    <Layout>
+      <Box mb={1}>
+        <Typography variant="h4" align="center">
+          Click on the tag which interests you
+        </Typography>
+      </Box>
+      <Paper component="ul" className={classes.root}>
+        {tags.map((tag, index) => (
+          <li key={index} className={classes.chipContainer}>
+            <Link component={GatsbyLink} to={`/tag/${normalizeURL(tag.fieldValue)}`} underline="none">
+              <Chip 
+                label={`${tag.fieldValue} (${tag.totalCount})`}
+                className={classes.chip}
+                clickable={true}
+              />
+            </Link>
+          </li>
+        ))}
+      </Paper>
+    </Layout>
+  );
+};
+
+export default TagsPage;
+
+export const query = graphql`
+  query {
+    allMdx(limit: 2000) {
+      group(field: frontmatter___tags) {
+        fieldValue
+        totalCount
+      }
+    }
+  }
+`;

--- a/src/pages/tags.jsx
+++ b/src/pages/tags.jsx
@@ -58,7 +58,10 @@ export default TagsPage;
 
 export const query = graphql`
   query {
-    allMdx(limit: 2000) {
+    allMdx(
+      limit: 2000
+      filter: { fields: { collection: { eq: "publications" } } }
+    ) {
       group(field: frontmatter___tags) {
         fieldValue
         totalCount

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Link as GatsbyLink, graphql } from "gatsby";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Link from "@material-ui/core/Link";
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardContent from '@material-ui/core/CardContent';
@@ -11,13 +10,15 @@ import Layout from "src/layout";
 
 const TaggedContent = ({ data, pageContext }) => {
   const { totalCount } = data.articles;
+  const description = data.tag? data.tag.description : "";
   return (
     <Layout>
-      <Box mb={1}>
+      <Box mb={2}>
         <Typography variant="h4" align="center">
           {pageContext.tag}
         </Typography>
         <Typography variant="h5" align="center">
+          {description && <span>{description}&nbsp;&middot;&nbsp;</span>} 
           {totalCount} {totalCount === 1? "article" : "articles"}
         </Typography>
       </Box>
@@ -45,7 +46,10 @@ export const query = graphql`
   query($tag: String) {
     articles: allMdx(
       sort: { fields: [frontmatter___date], order: DESC }
-      filter: { frontmatter: { tags: { in: [$tag] } } }
+      filter: { 
+        frontmatter: { tags: { in: [$tag] } } 
+        fields: { collection: { eq: "publications" } }
+      }
     ) {
       totalCount
       edges {
@@ -61,6 +65,10 @@ export const query = graphql`
           timeToRead
         }
       }
+    }
+    tag: tagsJson(tag: {eq: $tag}) {
+      description
+      related
     }
   }`;
 

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Link as GatsbyLink, graphql } from "gatsby";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import Link from "@material-ui/core/Link";
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardContent from '@material-ui/core/CardContent';
+
+import Layout from "src/layout";
+
+const TaggedContent = ({ data, pageContext }) => {
+  const { totalCount } = data.articles;
+  return (
+    <Layout>
+      <Box mb={1}>
+        <Typography variant="h4" align="center">
+          {pageContext.tag}
+        </Typography>
+        <Typography variant="h5" align="center">
+          {totalCount} {totalCount === 1? "article" : "articles"}
+        </Typography>
+      </Box>
+      {data.articles.edges.map((edge) => (
+        <Box component={Card} my={1}>
+          <CardActionArea component={GatsbyLink} to={`/articles/${edge.node.fields.slug}`}>
+            <CardContent>
+              <Typography variant="h5" color="textSecondary">
+                {edge.node.frontmatter.title}
+              </Typography>
+              <Typography variant="h6">
+                {edge.node.frontmatter.date} &middot;{" "}
+                {edge.node.timeToRead} min read
+              </Typography>
+              {edge.node.excerpt}
+            </CardContent>
+          </CardActionArea>
+        </Box>
+      ))}
+    </Layout>
+  );
+};
+
+export const query = graphql`
+  query($tag: String) {
+    articles: allMdx(
+      sort: { fields: [frontmatter___date], order: DESC }
+      filter: { frontmatter: { tags: { in: [$tag] } } }
+    ) {
+      totalCount
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            date(formatString: "YYYY-MM-DD")
+          }
+          excerpt(truncate: true, pruneLength: 300)
+          timeToRead
+        }
+      }
+    }
+  }`;
+
+export default TaggedContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5682,6 +5682,14 @@ gatsby-telemetry@^1.3.24:
     node-fetch "2.6.0"
     uuid "3.4.0"
 
+gatsby-transformer-json@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-json/-/gatsby-transformer-json-2.4.11.tgz#aeae29b0fa546a4443582499adfe3c9a04fd7295"
+  integrity sha512-eOZHf/azsIqz7pqYyPBdwk2jqiviaFZwuRQWYxfRpvyohPdSMAgrKgLreJaORfjt0+i3saRBXmkIFDq4Q0iJTA==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    bluebird "^3.7.2"
+
 gatsby@^2.24.23:
   version "2.24.23"
   resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-2.24.23.tgz#7733bcee32355732cca7a121ab036e259e0bb37a"


### PR DESCRIPTION
## :scroll: Description

Building on the category filters proposal.

### Changes
the navbar is controlled by siteMetadata:
+ `navbar.links` lists the names of pages from `/src/pages` that should appear on the right side of the navbar
+ `navbar.tags` lists the names of tags that should be accessible from the left side of the navbar. Make sure at least one article with that tag name exists, otherwise that page won't be created and the link will lead to a 404.

Article Nodes have an extra field called `collection: "publication"` to distinguish them from future additions to the website (ex: author pages).

If you want to add a description to a tag, put it in `/content/tags/tags.json`. It is an array of objects.
```json
{
    "tag": "My Tag Name",
    "description": "Where people debate linux distros",
    "related": []
}
```
The related field has no functional use yet but it's part of the schema so it's required. In the future, I might list the related tags as chips beneath the tag title. We don't have that many tags yet so I don't think it would look nice if implemented right now.

Articles are listed using cards right now, which is different from the home page. If we ever make a consistent article card, feel free to replace it.

## 💡 Motivation and Context

I based it off jekyl sites like https://cestlaz.github.io that have a page devoted to all the tags but the most important tags are in the navbar. Wordpress sites use a similar system, except they keep it in a sidebar on most themes.

Closes #29 . Closes #26  

## 🔮 Next steps

We should find a place to list tags in the article header. I don't have that branch but whoever is working on that feature should look into it.

It is possible to add images to each tag by adding an extra property in the `content/tags/tags.json` list.

## :camera: Screenshots / GIFs / Videos

The page at `/tags` lists all the tags that have been mentioned in articles:
![Screen Shot 2020-09-13 at 3 35 34 PM](https://user-images.githubusercontent.com/6315096/93026836-f9bde680-f5d6-11ea-92d8-6463f157775a.png)

The pages at `/tag/xyz` list the articles that have tag xyz. Here's a page with a description imported from `/content/tags/tags.json` automatically:
![Screen Shot 2020-09-13 at 3 35 52 PM](https://user-images.githubusercontent.com/6315096/93026868-24a83a80-f5d7-11ea-9c71-1828b2357fc4.png)

And here's a tag page with no description:
![Screen Shot 2020-09-13 at 3 36 16 PM](https://user-images.githubusercontent.com/6315096/93026879-2f62cf80-f5d7-11ea-8bbd-2c5d54930437.png)

